### PR TITLE
Add basic favorites API endpoint

### DIFF
--- a/geonode/api/api.py
+++ b/geonode/api/api.py
@@ -18,6 +18,7 @@ from geonode.layers.models import Layer
 from geonode.maps.models import Map
 from geonode.documents.models import Document
 from geonode.groups.models import GroupProfile
+from geonode.contrib.favorite.models import Favorite
 
 from taggit.models import Tag
 from django.core.serializers.json import DjangoJSONEncoder
@@ -26,6 +27,7 @@ from tastypie import fields
 from tastypie.resources import ModelResource
 from tastypie.constants import ALL
 from tastypie.utils import trailing_slash
+from tastypie.authorization import Authorization
 
 from django.db.models import Q
 
@@ -118,6 +120,36 @@ class TagResource(TypeFilteredResource):
             'slug': ALL,
         }
         serializer = CountJSONSerializer()
+
+class FavoriteResource(ModelResource):
+    """Favorites API"""
+    type = fields.CharField()
+    detail_url = fields.CharField()
+    thumbnail_url = fields.CharField()
+
+    def dehydrate_type(self, bundle):
+      return bundle.obj.content_type
+
+    def dehydrate_detail_url(self, bundle):
+        if str(bundle.obj.content_type) == "layer":
+            return reverse('layer_detail', args=[Layer.objects.get(id=bundle.obj.id)])
+
+    def dehydrate_thumbnail_url(self, bundle):
+        if str(bundle.obj.content_type) == "layer":
+            return Layer.objects.get(id=bundle.obj.id).thumbnail_url
+
+    def serialize(self, request, data, format, options={}):
+        options['something'] = 'anything'
+        return super(FavoriteResource, self).serialize(request, data, format, options)
+
+    def authorized_read_list(self, object_list, bundle):
+        return object_list.filter(user=bundle.request.user.id)
+
+    class Meta:
+        queryset = Favorite.objects.all()
+        resource_name = 'favorites'
+        allowed_methods = ['get']
+        authorization = Authorization()
 
 
 class RegionResource(TypeFilteredResource):

--- a/geonode/api/urls.py
+++ b/geonode/api/urls.py
@@ -1,7 +1,7 @@
 from tastypie.api import Api
 
 from .api import TagResource, TopicCategoryResource, ProfileResource, \
-    GroupResource, RegionResource
+    GroupResource, RegionResource, FavoriteResource
 from .resourcebase_api import LayerResource, MapResource, DocumentResource, \
     ResourceBaseResource, FeaturedResourceBaseResource
 
@@ -17,3 +17,4 @@ api.register(RegionResource())
 api.register(TopicCategoryResource())
 api.register(GroupResource())
 api.register(FeaturedResourceBaseResource())
+api.register(FavoriteResource())


### PR DESCRIPTION
This adds /api/favorites/ for use in the 'mini-explore' panel in MapLoom. @milafrerichs let me know what else you might need.

https://github.com/MapStory/mapstory/issues/1362

```
{
	meta: {
		limit: 1000,
		next: null,
		offset: 0,
		previous: null,
		total_count: 2
	},
	objects: [{
		created_on: "2016-03-08T16:27:06.164175",
		detail_url: "/layers/San%20Andres%20Y%20Providencia%20Poi",
		id: 1,
		object_id: 6,
		resource_uri: "/api/favorites/1/",
		thumbnail_url: "http://localhost:8000/uploaded/thumbs/layer-29d334aa-df3a-11e5-be2c-08002755575e-thumb.png",
		type: "layer"
	}, {
		created_on: "2016-03-08T16:27:13.466210",
		detail_url: "/layers/San%20Andres%20Y%20Providencia%20Natural",
		id: 2,
		object_id: 7,
		resource_uri: "/api/favorites/2/",
		thumbnail_url: "http://localhost:8000/uploaded/thumbs/layer-2bf66df6-df3a-11e5-be2c-08002755575e-thumb.png",
		type: "layer"
	}]
}
```