### PR TITLE
Allow MapStory objects to be removed; Fix for search querying for MapStory objects

### DIFF
--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -182,7 +182,7 @@ class CommonModelApi(ModelResource):
             subtypes = []
 
             for type in type_facets:
-                if type in ["map", "layer", "document", "user", "group"]:
+                if type in ["map", "mapstory", "layer", "document", "user", "group"]:
                     # Type is one of our Major Types (not a sub type)
                     types.append(type)
                 elif type in LAYER_SUBTYPES.keys():

--- a/geonode/maps/models.py
+++ b/geonode/maps/models.py
@@ -49,6 +49,9 @@ logger = logging.getLogger("geonode.maps.models")
 
 class MapStory(ResourceBase):
 
+    def get_absolute_url(self):
+        return reverse('mapstory.views.map_detail', None, [str(self.id)])
+
     @property
     def chapters(self):
         return self.chapter_list.order_by('chapter_index')
@@ -633,3 +636,4 @@ class MapSnapshot(models.Model):
 
 signals.pre_delete.connect(pre_delete_map, sender=Map)
 signals.post_save.connect(resourcebase_post_save, sender=Map)
+signals.post_save.connect(resourcebase_post_save, sender=MapStory)

--- a/geonode/tasks/deletion.py
+++ b/geonode/tasks/deletion.py
@@ -1,7 +1,6 @@
 from geonode.layers.models import Layer
-from geonode.maps.models import Map
+from geonode.maps.models import Map, MapStory
 from celery.task import task
-
 
 @task(name='geonode.tasks.deletion.delete_layer', queue='cleanup')
 def delete_layer(object_id):
@@ -28,4 +27,22 @@ def delete_map(object_id):
         return
 
     map_obj.layer_set.all().delete()
+    map_obj.delete()
+
+@task(name='geonode.tasks.deletion.delete_mapstory', queue='cleanup')
+def delete_mapstory(object_id):
+    """
+    Deletes a mapstory and the associated maps and the associated map layers.
+    """
+
+    try:
+        map_obj = MapStory.objects.get(id=object_id)
+    except MapStory.DoesNotExist:
+        return
+
+    chapters = map_obj.chapters
+    for chapter in chapters:
+        chapter.layer_set.all().delete()
+        chapter.delete()
+
     map_obj.delete()


### PR DESCRIPTION
Note that for previously created MapStories, we need to call a `save()` on them so that they are indexed and assigned their `detail_url` properly. Should be as simple as running something like this in the command line:
```
from geonode.maps.models import MapStory
for mapstory in MapStory.objects.all():
    mapstory.save()
```