### PR TITLE
Create links for MapStory thumbnails so post_save signal does not ove…

### DIFF
--- a/geonode/maps/models.py
+++ b/geonode/maps/models.py
@@ -44,6 +44,8 @@ from geonode.security.models import remove_object_permissions
 
 from agon_ratings.models import OverallRating
 
+from geonode.base.models import Link
+
 logger = logging.getLogger("geonode.maps.models")
 
 
@@ -103,9 +105,19 @@ class MapStory(ResourceBase):
             return
 
         chapter_base = ResourceBase.objects.get(id=first_chapter_obj.id)
+        url = chapter_base.thumbnail_url
         ResourceBase.objects.filter(id=self.id).update(
-            thumbnail_url=chapter_base.thumbnail_url
+            thumbnail_url=url
         )
+
+        Link.objects.get_or_create(resource=self,
+                           url=url,
+                           defaults=dict(
+                               name='Thumbnail',
+                               extension='png',
+                               mime='image/png',
+                               link_type='image',
+                           ))
 
 
     class Meta(ResourceBase.Meta):


### PR DESCRIPTION
…rwrite them

This fix will only apply to newly created MapStories since previously created ones with or without thumbnails don't have this Link object created.

This should be fixable just by rerunning `update_thumbnail` on all MapStories, I believe:

```
from geonode.maps.models import MapStory
for mapstory in MapStory.objects.all():
    first_chapter_obj = mapstory.chapters.first()
    mapstory.update_thumbnail(first_chapter_obj)
    mapstory.save()
```

Assumes the chapter is intact and has a good thumbnail.
