### PR TITLE
Fix Admin NoneType Errors on Stories and Layers

### DIFF
--- a/geonode/base/admin.py
+++ b/geonode/base/admin.py
@@ -130,5 +130,10 @@ admin.site.register(License, LicenseAdmin)
 
 
 class ResourceBaseAdminForm(autocomplete_light.ModelForm):
-    # keywords = TaggitField(widget=TaggitWidget('TagAutocomplete'), required=False)
-    keywords = TaggitField(widget=TaggitWidget(), required=False)
+    # We need to specify autocomplete='TagAutocomplete' or admin views like
+    # /admin/maps/map/2/ raise exceptions during form rendering.
+    # But if we specify it up front, TaggitField.__init__ throws an exception
+    # which prevents app startup. Therefore, we defer setting the widget until
+    # after that's done.
+    keywords = TaggitField(required=False)
+    keywords.widget = TaggitWidget(autocomplete='TagAutocomplete')


### PR DESCRIPTION
This PR fixes Github issue #437 where admin views for layers and stories were returning a NoneType exception.  Based on https://github.com/GeoNode/geonode/pull/2580/files which is a Geonode PR ahead of where our branch currently is.