### PR TITLE
Mapstory arcrest updates

### DIFF
--- a/geonode/services/serviceprocessors/arcgis.py
+++ b/geonode/services/serviceprocessors/arcgis.py
@@ -33,7 +33,7 @@ from geonode.base.models import Link
 from geonode.layers.models import Layer
 from geonode.layers.utils import create_thumbnail
 
-from arcrest import MapService as ArcMapService, ImageService as ArcImageService
+from arcrest.ags import MapService as ArcMapService, ImageService as ArcImageService
 
 from .. import enumerations
 from ..enumerations import INDEXED

--- a/geonode/services/serviceprocessors/arcgis.py
+++ b/geonode/services/serviceprocessors/arcgis.py
@@ -107,17 +107,17 @@ class ArcMapServiceHandler(base.ServiceHandlerBase):
             method=self.indexing_method,
             owner=owner,
             parent=parent,
-            version=self.parsed_service._json_struct["currentVersion"],
+            version=self.parsed_service.currentVersion,
             name=self.name,
             title=self.title,
-            abstract=self.parsed_service._json_struct["serviceDescription"] or _(
+            abstract=self.parsed_service.serviceDescription or _(
                 "Not provided"),
             online_resource=self.parsed_service.url,
         )
         return instance
 
     def get_keywords(self):
-        return self.parsed_service._json_struct["capabilities"].split(",")
+        return self.parsed_service.documentInfo['Keywords'].split(',')
 
     def get_resource(self, resource_id):
         ll = None

--- a/geonode/services/serviceprocessors/arcgis.py
+++ b/geonode/services/serviceprocessors/arcgis.py
@@ -212,7 +212,7 @@ class ArcMapServiceHandler(base.ServiceHandlerBase):
         return geonode_projection in "EPSG:{}".format(srs)
 
     def _get_indexed_layer_fields(self, layer_meta):
-        srs = "EPSG:%s" % layer_meta.extent.spatialReference.wkid
+        srs = utils.epsg_string(layer_meta.extent)
         bbox = utils.decimal_encode([layer_meta.extent.xmin,
                                      layer_meta.extent.ymin,
                                      layer_meta.extent.xmax,

--- a/geonode/services/serviceprocessors/arcgis.py
+++ b/geonode/services/serviceprocessors/arcgis.py
@@ -68,7 +68,6 @@ class ArcMapServiceHandler(base.ServiceHandlerBase):
         self.proxy_base = None
         self.url = url
         self.parsed_service = ArcMapService(self.url)
-        extent, srs = utils.get_esri_extent(self.parsed_service)
         try:
             _sname = utils.get_esri_service_name(self.url)
             _title_safe = safe(os.path.basename(os.path.normpath(_sname)))
@@ -309,7 +308,6 @@ class ArcImageServiceHandler(ArcMapServiceHandler):
         self.proxy_base = None
         self.url = url
         self.parsed_service = ArcImageService(self.url)
-        extent, srs = utils.get_esri_extent(self.parsed_service)
         try:
             _sname = utils.get_esri_service_name(self.url)
             _title_safe = safe(os.path.basename(os.path.normpath(_sname)))

--- a/geonode/services/utils.py
+++ b/geonode/services/utils.py
@@ -20,7 +20,6 @@
 import re
 import math
 import logging
-from decimal import Decimal
 
 logger = logging.getLogger(__name__)
 
@@ -88,40 +87,19 @@ def get_esri_service_name(url):
         return result.group(1)
 
 
-def get_esri_extent(esriobj):
-    """
-    Get the extent of an ESRI resource
-    """
-
-    extent = None
-    srs = None
-
-    try:
-        if 'fullExtent' in esriobj._json_struct:
-            extent = esriobj._json_struct['fullExtent']
-    except Exception as err:
-        logger.error(err, exc_info=True)
-
-    try:
-        if 'extent' in esriobj._json_struct:
-            extent = esriobj._json_struct['extent']
-    except Exception as err:
-        logger.error(err, exc_info=True)
-
-    try:
-        srs = extent['spatialReference']['wkid']
-    except Exception as err:
-        logger.error(err, exc_info=True)
-
-    return [extent, srs]
-
-
 def decimal_encode(bbox):
     _bbox = []
-    for o in [float(coord) for coord in bbox]:
-        if isinstance(o, Decimal):
-            o = (str(o) for o in [o])
-        _bbox.append("{0:.15f}".format(round(o, 2)))
+    _srid = None
+    for o in bbox:
+        try:
+            o = float(o)
+        except BaseException:
+            o = None if 'EPSG' not in o else o
+        if o and isinstance(o, float):
+            _bbox.append("{0:.15f}".format(round(o, 2)))
+        elif o and 'EPSG' in o:
+            _srid = o
+    _bbox = _bbox if not _srid else _bbox + [_srid]
     return _bbox
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,7 +68,6 @@ geonode-user-messages==0.1.14
 geonode-avatar==2.1.8
 geonode-announcements==1.0.13
 geonode-agon-ratings==0.3.8
-arcrest>=10.0
 geonode-dialogos==1.2
 gsconfig>=1.0.10
 gn-gsimporter>=1.0.9
@@ -97,6 +96,8 @@ pytz==2018.9
 requests>=2.20.0
 simplejson==3.16.0
 timeout-decorator==0.4.1
+python_resize_image==1.1.19
+ArcREST-Package==3.5.9
 
 # required by monitoring
 psutil==5.6.1

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,10 @@
 
 try:  # for pip >= 10
     from pip._internal.req import parse_requirements
-    from pip._internal.download import PipSession
+    try:
+        from pip._internal.download import PipSession
+    except ImportError:  # for pip >= 20
+        from pip._internal.network.session import PipSession
 except ImportError:  # for pip <= 9.0.3
     from pip.req import parse_requirements
     from pip.download import PipSession


### PR DESCRIPTION
Since GeoNode `2.8.x` proper is no longer maintained, the backport for the ArcREST fixes and hotfix for pip breaking the build must go directly into MapStory's deps/geonode. The proper solution going forward will require updating to `2.10.x` which will have these same changes pushed to it upstream.